### PR TITLE
Fix/timeouts

### DIFF
--- a/src/plugins/elasticsearch/lib/create_proxy.js
+++ b/src/plugins/elasticsearch/lib/create_proxy.js
@@ -1,12 +1,18 @@
 const createAgent = require('./create_agent');
 const mapUri = require('./map_uri');
 const { resolve } = require('url');
+const { assign } = require('lodash');
 
 function createProxy(server, method, route, config) {
 
   const options = {
     method: method,
     path: createProxy.createPath(route),
+    config: {
+      timeout: {
+        socket: server.config().get('elasticsearch.requestTimeout')
+      }
+    },
     handler: {
       proxy: {
         mapUri: mapUri(server),
@@ -18,7 +24,7 @@ function createProxy(server, method, route, config) {
     },
   };
 
-  if (config) options.config = config;
+  assign(options.config, config);
 
   server.route(options);
 };

--- a/src/plugins/elasticsearch/lib/expose_client.js
+++ b/src/plugins/elasticsearch/lib/expose_client.js
@@ -18,6 +18,8 @@ module.exports = function (server) {
       clientKey: config.get('elasticsearch.ssl.key'),
       ca: config.get('elasticsearch.ssl.ca'),
       apiVersion: config.get('elasticsearch.apiVersion'),
+      pingTimeout: config.get('elasticsearch.pingTimeout'),
+      requestTimeout: config.get('elasticsearch.requestTimeout'),
       keepAlive: true,
       auth: true
     });
@@ -43,6 +45,8 @@ module.exports = function (server) {
       ssl: ssl,
       apiVersion: options.apiVersion,
       keepAlive: options.keepAlive,
+      pingTimeout: options.pingTimeout,
+      requestTimeout: options.requestTimeout,
       log: function () {
         this.error = function (err) {
           server.log(['error', 'elasticsearch'], err);

--- a/src/plugins/elasticsearch/lib/health_check.js
+++ b/src/plugins/elasticsearch/lib/health_check.js
@@ -22,7 +22,7 @@ module.exports = function (plugin, server) {
   plugin.status.yellow('Waiting for Elasticsearch');
 
   function waitForPong() {
-    return client.ping({ requestTimeout: 1500 }).catch(function (err) {
+    return client.ping({ requestTimeout: config.get('elasticsearch.requestTimeout') }).catch(function (err) {
       if (!(err instanceof NoConnections)) throw err;
 
       plugin.status.red(format('Unable to connect to Elasticsearch at %s.', config.get('elasticsearch.url')));

--- a/src/plugins/elasticsearch/lib/health_check.js
+++ b/src/plugins/elasticsearch/lib/health_check.js
@@ -22,7 +22,7 @@ module.exports = function (plugin, server) {
   plugin.status.yellow('Waiting for Elasticsearch');
 
   function waitForPong() {
-    return client.ping({ requestTimeout: config.get('elasticsearch.requestTimeout') }).catch(function (err) {
+    return client.ping().catch(function (err) {
       if (!(err instanceof NoConnections)) throw err;
 
       plugin.status.red(format('Unable to connect to Elasticsearch at %s.', config.get('elasticsearch.url')));


### PR DESCRIPTION
- Pass `requestTimeout` and `pingTimeout` settings to exposed client instance
- Fall back to client settings when pinging for health check
- Set proxy socket timeout to `requestTimeout` value